### PR TITLE
Add multi-user support

### DIFF
--- a/comfy/photoshop_manager.py
+++ b/comfy/photoshop_manager.py
@@ -1,0 +1,116 @@
+import asyncio
+from .photoshop_instance import PhotoshopInstance
+DEFAULT_ID = 0
+
+class PhotoshopManager:
+    _instance = None
+
+    @classmethod
+    def instance(cls) -> 'PhotoshopManager':
+        if cls._instance is None:
+            cls._instance = PhotoshopManager()
+        return cls._instance
+
+    def __init__(self):
+        # client id info
+        self.ip_to_client_id_list = {}
+        self.client_id_to_userid = {}
+        # ps instance info
+        self.ip_to_ps_instance_list = {}
+        # final match
+        self.client_id_to_ps_instance = {}
+
+    # get instance from client information, match new instance if not exist
+    def instance_from_client_info(self, ip, client_id, user_id) -> PhotoshopInstance:
+        if not ip: return None
+        if not client_id: user_id = 0
+        if not user_id: user_id = 0
+        instance = self.instance_from_client_id(client_id)
+        if instance is not None:
+            return instance
+        self._add_new_client(ip, client_id, user_id)
+        self._client_match_ps(ip, client_id, user_id)
+        return self.instance_from_client_id(client_id)
+    
+    # get instance from client id
+    def instance_from_client_id(self, client_id) -> PhotoshopInstance:
+        return self.client_id_to_ps_instance.get(client_id, None)
+
+    # create new instance and record
+    async def new_ps_instance(self, sdppp, sid, ip, user_id) -> PhotoshopInstance:
+        if not ip: return None
+        if not user_id: user_id = 0
+        # create new instance
+        instance = PhotoshopInstance(sdppp, sid, user_id)
+        instance.on_destroy = self._on_instance_destroy
+        # record new instance
+        await self._add_new_ps_instance(ip, instance)
+        return instance
+
+    #------------------------------------------------------------------------------------------------------------------------------------------------
+    # callback when instance is destroyed and remove from record
+    def _on_instance_destroy(self, instance):
+        self._remove_instance(instance)
+
+    # record new ps instance for matching
+    async def _add_new_ps_instance(self, ip, instance):
+        # find old one and destroy
+        same_ip_list = self.ip_to_ps_instance_list.get(ip, [])
+        for check_instance in same_ip_list:
+            if check_instance.uid == instance.uid:
+                await check_instance.destroy()
+        # record ip to instance
+        ps_instance_list = self.ip_to_ps_instance_list.get(ip, [])
+        if instance not in ps_instance_list:
+            ps_instance_list.append(instance)
+        self.ip_to_ps_instance_list[ip] = ps_instance_list
+
+    # record new client id
+    def _add_new_client(self, ip, client_id, user_id):
+        # record client id, if exist, do nothing
+        client_id_list = self.ip_to_client_id_list.get(ip, [])
+        if client_id in client_id_list:
+            return
+        client_id_list.append(client_id)
+        self.ip_to_client_id_list[ip] = client_id_list
+        # record user_id
+        self.client_id_to_userid[client_id] = user_id
+
+    # match client id to ps instance for prompt use
+    # there are several ways to match:
+    # 1. one to one match(local network most likely): same ip client and ps instance, assign to it
+    # 2. multiple ps instance under the same ip(remote service most likely), check user id
+    def _client_match_ps(self, ip, client_id, user_id):
+        # check existing pair
+        instance = self.client_id_to_ps_instance.get(client_id, None)
+        if instance is not None:
+            return
+        # check same ip  ps instance
+        ps_instance_list = self.ip_to_ps_instance_list.get(ip, [])
+        count = len(ps_instance_list)
+        if count <= 0:
+            return
+        # if only one same ip ps instance, assign client id
+        if count == 1:
+            self.client_id_to_ps_instance[client_id] = ps_instance_list[0]
+            return
+        # if more than one same ip ps instance, check same user_id, same ip + same user id = same ps instance
+        ps_user_id_list = [instance.uid for instance in ps_instance_list]
+        try:
+            check_index = ps_user_id_list.index(user_id)
+        except:
+            check_index = None
+        if check_index is None:
+            return
+        self.client_id_to_ps_instance[client_id] = ps_instance_list[check_index]
+
+    def _remove_instance(self, instance):
+        # remove id from ip to instance list
+        for ip, ps_instance_list in self.ip_to_ps_instance_list.items():
+            if instance in ps_instance_list:
+                ps_instance_list.remove(instance)
+        # remove instance from client id to instance
+        for client_id in list(self.client_id_to_ps_instance.keys()):
+            check_instance = self.client_id_to_ps_instance.get(client_id, None)
+            if check_instance == instance:
+                self.client_id_to_ps_instance.pop(client_id, None)

--- a/comfy/sdppp.py
+++ b/comfy/sdppp.py
@@ -57,13 +57,13 @@ class SDPPP:
                 self.photoshop_instances[sid] = await PhotoshopManager.instance().new_ps_instance(self, sid, ip, user_id)
 
             elif qsobj['type'] == 'comfyui':
-                self.comfyui_instances[sid] = True
                 client_id = qsobj.get('client_id', None)
                 if not client_id:
                     client_id = 0
                 user_id = qsobj.get('user_id', None)
                 if not user_id:
                     user_id = 0
+                self.comfyui_instances[sid] = client_id
                 PhotoshopManager.instance().instance_from_client_info(ip, client_id, user_id)
 
             else:
@@ -91,7 +91,10 @@ class SDPPP:
             layer_strs = instance.get_base_layers()
             bounds_strs = instance.get_bounds_layers()
             set_layer_strs = instance.get_set_layers()
-            for sid, instance in self.comfyui_instances.items():
+            for sid, client_id in self.comfyui_instances.items():
+                check_instance = PhotoshopManager.instance().instance_from_client_id(client_id)
+                if check_instance != instance:
+                    continue
                 await sio.emit('sync_layers', {
                     'layer_strs': layer_strs,
                     'bound_strs': bounds_strs,

--- a/comfy/static/js/sd-ppp.js
+++ b/comfy/static/js/sd-ppp.js
@@ -52,7 +52,9 @@ app.registerExtension({
             path: '/sd-ppp/',
             query: {
                 version: 1,
-                type: 'comfyui'
+                type: 'comfyui',
+                client_id: api.clientId,
+                user_id: getUserId(),
             }
         });
 

--- a/photoshop/dist/index.js
+++ b/photoshop/dist/index.js
@@ -5081,10 +5081,10 @@ const SPECIAL_LAYER_USE_SELECTION = '### Use Selection ###';
 const SPECIAL_LAYER_NEW_LAYER = '### New Layer ###';
 const SPECIAL_LAYER_SAME_AS_LAYER = '### Same as Layer ###';
 const SPECIAL_LAYER_NAME_TO_ID = {
-  SPECIAL_LAYER_USE_CANVAS: 0,
-  SPECIAL_LAYER_USE_SELECTION: -1,
-  SPECIAL_LAYER_NEW_LAYER: -2,
-  SPECIAL_LAYER_SAME_AS_LAYER: -3
+  [SPECIAL_LAYER_USE_CANVAS]: 0,
+  [SPECIAL_LAYER_USE_SELECTION]: -1,
+  [SPECIAL_LAYER_NEW_LAYER]: -2,
+  [SPECIAL_LAYER_SAME_AS_LAYER]: -3
 };
 function unTrimImageData(intersectImageDataArray, toImageDataArray, fromImageBounds, toImageBounds) {
   const fromLeft = fromImageBounds.left;

--- a/photoshop/dist/index.js
+++ b/photoshop/dist/index.js
@@ -152,15 +152,13 @@ class Main extends react__WEBPACK_IMPORTED_MODULE_0__.Component {
           ui_ExpandMore: !expandMore
         });
       }
-    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", {
-      class: "expand-menu-arrow"
-    }, expandMore ? "▼" : "▶️"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, "more")), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, expandMore ? "▼ more" : "▶ more")), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
       class: "content"
     }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
-      class: "input-row"
-    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, "user-id:"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
-      class: "input-label",
+      class: "input-row",
       id: "user-id-bar"
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, "user-name:"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+      class: "input-label"
     }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, this.state.userId), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-textfield", {
       label: "USER ID",
       onInput: ev => {
@@ -5256,10 +5254,12 @@ ___CSS_LOADER_EXPORT___.push([module.id, `.tabbar {
     flex-direction: row;
     align-items: center;
     height: 30px;
+    width: 100%;
 }
 
 .input-label {
     position: relative;
+    flex: 1;
 }
 .input-label sp-label {
     width: calc(100% - 15px);
@@ -5284,13 +5284,12 @@ ___CSS_LOADER_EXPORT___.push([module.id, `.tabbar {
     display: flex;
     flex-direction: row;
     align-items: center;
-    height: 20px;
+    height: 15px;
     padding: 5px;
-    background-color: rgba(0, 0, 0, 0.3);
 }
 .expand-menu .expand-menu-arrow {
     font-weight: bold;
-    width: 15px;
+    text-align: center;
 }
 .expand-menu .expand-menu-title sp-icon {
     height: 15px;

--- a/photoshop/dist/index.js
+++ b/photoshop/dist/index.js
@@ -96,7 +96,9 @@ __webpack_require__.r(__webpack_exports__);
 class Main extends react__WEBPACK_IMPORTED_MODULE_0__.Component {
   state = {
     comfyURL: '',
-    isConnected: false
+    isConnected: false,
+    userId: uxp__WEBPACK_IMPORTED_MODULE_2__.userInfo.userId().slice(0, 10),
+    ui_ExpandMore: false
   };
   componentDidMount() {
     _system_ComfyConnection__WEBPACK_IMPORTED_MODULE_1__["default"].onConnectStateChange(() => {
@@ -131,6 +133,7 @@ class Main extends react__WEBPACK_IMPORTED_MODULE_0__.Component {
     if (!_system_ComfyConnection__WEBPACK_IMPORTED_MODULE_1__["default"].instance?.isConnected) _system_ComfyConnection__WEBPACK_IMPORTED_MODULE_1__["default"].createInstance(this.state.comfyURL, this.state.userId);else _system_ComfyConnection__WEBPACK_IMPORTED_MODULE_1__["default"].instance.disconnect();
   }
   render() {
+    const expandMore = this.state.ui_ExpandMore;
     return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement(react__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-textfield", {
       id: "url-bar",
       label: "ComfyURL",
@@ -139,16 +142,39 @@ class Main extends react__WEBPACK_IMPORTED_MODULE_0__.Component {
       },
       value: this.state.comfyURL,
       placeholder: "http://127.0.0.1:8188"
-    }), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-textfield", {
-      id: "user-id-bar",
+    }), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-divider", null), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+      id: "connection-more",
+      className: expandMore ? "expand-menu expand" : "expand-menu collapse"
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+      class: "expand-menu-title",
+      onClick: () => {
+        this.setState({
+          ui_ExpandMore: !expandMore
+        });
+      }
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", {
+      class: "expand-menu-arrow"
+    }, expandMore ? "▼" : "▶️"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, "more")), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+      class: "content"
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+      class: "input-row"
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, "user-id:"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+      class: "input-label",
+      id: "user-id-bar"
+    }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-label", null, this.state.userId), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-textfield", {
       label: "USER ID",
       onInput: ev => {
-        this.state.userId = ev.currentTarget.value;
-        if (!this.state.userId) uxp__WEBPACK_IMPORTED_MODULE_2__.storage.secureStorage.removeItem('userId');else uxp__WEBPACK_IMPORTED_MODULE_2__.storage.secureStorage.setItem('userId', this.state.userId);
+        const userID = ev.currentTarget.value;
+        if (!userID) uxp__WEBPACK_IMPORTED_MODULE_2__.storage.secureStorage.removeItem('userId');else {
+          uxp__WEBPACK_IMPORTED_MODULE_2__.storage.secureStorage.setItem('userId', this.state.userId);
+          this.setState({
+            userId: userID
+          });
+        }
       },
       value: this.state.userId,
       placeholder: "User Name: Change if sharing remote server"
-    }), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+    }))))), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
       className: "button-box"
     }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("sp-button", {
       id: "connect-btn",
@@ -5224,6 +5250,61 @@ ___CSS_LOADER_EXPORT___.push([module.id, `.tabbar {
 }
 #connect-btn {
     text-align: center;
+}
+.input-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 30px;
+}
+
+.input-label {
+    position: relative;
+}
+.input-label sp-label {
+    width: calc(100% - 15px);
+    height: 100%;
+    margin-left: 15px;
+}
+.input-label sp-textfield {
+    position: absolute;
+    width: 100%;
+    top: -5px;
+    left: 0;
+    visibility: hidden;
+    z-index: 5;
+}
+.input-label sp-textfield:focus {
+    visibility: visible;
+} 
+.input-label:hover sp-textfield{
+    visibility: visible;
+}
+.expand-menu .expand-menu-title {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 20px;
+    padding: 5px;
+    background-color: rgba(0, 0, 0, 0.3);
+}
+.expand-menu .expand-menu-arrow {
+    font-weight: bold;
+    width: 15px;
+}
+.expand-menu .expand-menu-title sp-icon {
+    height: 15px;
+    width: 20px;
+    color: #ccc;
+}
+.expand-menu .content {
+    margin-left: 15px
+}
+.expand-menu.collapse .content {
+    display: none;
+}
+.expand-menu.expand .content {
+    display: flex;
 }`, ""]);
 // Exports
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (___CSS_LOADER_EXPORT___);

--- a/photoshop/dist/manifest.json
+++ b/photoshop/dist/manifest.json
@@ -41,19 +41,19 @@
       },
       "minimumSize": {
         "width": 300,
-        "height": 100
+        "height": 130
       },
       "maximumSize": {
         "width": 400,
-        "height": 100
+        "height": 130
       },
       "preferredDockedSize": {
         "width": 300,
-        "height": 100
+        "height": 130
       },
       "preferredFloatingSize": {
         "width": 300,
-        "height": 100
+        "height": 130
       },
       "icons": [
         {

--- a/photoshop/dist/manifest.json
+++ b/photoshop/dist/manifest.json
@@ -11,6 +11,7 @@
     }
   ],
   "requiredPermissions": {
+    "enableUserInfo": true,  
     "network": {
         "domains": "all"
     },
@@ -41,19 +42,19 @@
       },
       "minimumSize": {
         "width": 300,
-        "height": 130
+        "height": 160
       },
       "maximumSize": {
         "width": 400,
-        "height": 130
+        "height": 160
       },
       "preferredDockedSize": {
         "width": 300,
-        "height": 130
+        "height": 160
       },
       "preferredFloatingSize": {
         "width": 300,
-        "height": 130
+        "height": 160
       },
       "icons": [
         {

--- a/photoshop/plugin/manifest.json
+++ b/photoshop/plugin/manifest.json
@@ -41,19 +41,19 @@
       },
       "minimumSize": {
         "width": 300,
-        "height": 100
+        "height": 130
       },
       "maximumSize": {
         "width": 400,
-        "height": 100
+        "height": 130
       },
       "preferredDockedSize": {
         "width": 300,
-        "height": 100
+        "height": 130
       },
       "preferredFloatingSize": {
         "width": 300,
-        "height": 100
+        "height": 130
       },
       "icons": [
         {

--- a/photoshop/plugin/manifest.json
+++ b/photoshop/plugin/manifest.json
@@ -11,6 +11,7 @@
     }
   ],
   "requiredPermissions": {
+    "enableUserInfo": true,  
     "network": {
         "domains": "all"
     },
@@ -41,19 +42,19 @@
       },
       "minimumSize": {
         "width": 300,
-        "height": 130
+        "height": 160
       },
       "maximumSize": {
         "width": 400,
-        "height": 130
+        "height": 160
       },
       "preferredDockedSize": {
         "width": 300,
-        "height": 130
+        "height": 160
       },
       "preferredFloatingSize": {
         "width": 300,
-        "height": 130
+        "height": 160
       },
       "icons": [
         {

--- a/photoshop/src/controllers/PanelController.jsx
+++ b/photoshop/src/controllers/PanelController.jsx
@@ -30,7 +30,7 @@ export class PanelController {
 
     create() {
         this[_root] = document.createElement("div");
-        this[_root].style.height = "100vh";
+        this[_root].style.height = "130vh";
         this[_root].style.overflow = "auto";
         this[_root].style.padding = "8px";
 

--- a/photoshop/src/index.jsx
+++ b/photoshop/src/index.jsx
@@ -6,7 +6,7 @@ import Main from "./panels/Main.jsx";
 
 import { entrypoints } from "uxp"; 
 
-const demosController =  new PanelController(() => <Main/>, {id: "comfy-connect", menuItems: [
+const demosController = new PanelController(() => <Main/>, {id: "comfy-connect", menuItems: [
     // { id: "reload1", label: "Reload Plugin", enabled: true, checked: false, oninvoke: () => location.reload() },
     // { id: "dialog1", label: "About this Plugin", enabled: true, checked: false, oninvoke: () => aboutController.run() },
 ] });

--- a/photoshop/src/panels/Main.jsx
+++ b/photoshop/src/panels/Main.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import ComfyConnection from "../system/ComfyConnection";
-import { storage } from "uxp";
+import { storage, userInfo } from "uxp";
 
 export default class Main extends React.Component {
     state = {
         comfyURL: '', 
-        isConnected: false 
+        isConnected: false,
+        userId: userInfo.userId().slice(0, 10),
+
+        ui_ExpandMore: false,
     }
 
     componentDidMount() {
@@ -42,9 +45,9 @@ export default class Main extends React.Component {
     }
 
     render() {
+        const expandMore = this.state.ui_ExpandMore;
         return (
             <> 
-
                 <sp-textfield 
                     id="url-bar" 
                     label="ComfyURL" 
@@ -52,19 +55,38 @@ export default class Main extends React.Component {
                     value={this.state.comfyURL} 
                     placeholder="http://127.0.0.1:8188"
                 ></sp-textfield>
-                <sp-textfield 
-                    id="user-id-bar" 
-                    label="USER ID" 
-                    onInput={(ev) => { 
-                        this.state.userId = ev.currentTarget.value;
-                        if (!this.state.userId) 
-                            storage.secureStorage.removeItem('userId');
-                        else
-                            storage.secureStorage.setItem('userId', this.state.userId);
-                    }} 
-                    value={this.state.userId} 
-                    placeholder="User Name: Change if sharing remote server"
-                ></sp-textfield>
+                <sp-divider />
+                <div id="connection-more" className={expandMore ? "expand-menu expand" : "expand-menu collapse"}>
+                    <div class="expand-menu-title" onClick={() => { this.setState({ui_ExpandMore: !expandMore}) }}>
+                        <sp-label class="expand-menu-arrow">{expandMore ? "▼" : "▶️"}</sp-label>
+                        {/* <sp-icon size="s" name={expandMore ? "ui:ChevronDownSmall" : "ui:ChevronRightSmall"}></sp-icon> */}
+                        <sp-label>more</sp-label>
+                    </div>
+                    <div class="content">
+                        <div class="input-row">
+                            <sp-label>user-id:</sp-label>
+                            <div class="input-label" id="user-id-bar">
+                                <sp-label>{this.state.userId}</sp-label>
+                                <sp-textfield 
+                                    label="USER ID" 
+                                    onInput={(ev) => { 
+                                        const userID = ev.currentTarget.value;
+                                        if (!userID) 
+                                            storage.secureStorage.removeItem('userId');
+                                        else {
+                                            storage.secureStorage.setItem('userId', this.state.userId);
+                                            this.setState({
+                                                userId: userID
+                                            })
+                                        }
+                                    }} 
+                                    value={this.state.userId} 
+                                    placeholder="User Name: Change if sharing remote server"
+                                ></sp-textfield>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div className="button-box">
                     <sp-button 
                         id="connect-btn"

--- a/photoshop/src/panels/Main.jsx
+++ b/photoshop/src/panels/Main.jsx
@@ -17,6 +17,13 @@ export default class Main extends React.Component {
                 comfyURL: instance ? instance.comfyURL : ''
             })
         });
+        storage.secureStorage.getItem('userId').then((value) => {
+            if (!value) return
+            this.setState({ userId: Buffer.from(value).toString() })
+            if (this.state.userId) {
+                console.log('userId:', this.state.userId)
+            }
+        })
         storage.secureStorage.getItem('comfyURL').then((value) => {
             if (!value) return
             this.setState({ comfyURL: Buffer.from(value).toString() })
@@ -29,7 +36,7 @@ export default class Main extends React.Component {
 
     doConnectOrDisconnect() {
         if (!ComfyConnection.instance?.isConnected) 
-            ComfyConnection.createInstance(this.state.comfyURL);
+            ComfyConnection.createInstance(this.state.comfyURL, this.state.userId);
         else 
             ComfyConnection.instance.disconnect();
     }
@@ -44,6 +51,19 @@ export default class Main extends React.Component {
                     onInput={(ev) => { this.state.comfyURL = ev.currentTarget.value }} 
                     value={this.state.comfyURL} 
                     placeholder="http://127.0.0.1:8188"
+                ></sp-textfield>
+                <sp-textfield 
+                    id="user-id-bar" 
+                    label="USER ID" 
+                    onInput={(ev) => { 
+                        this.state.userId = ev.currentTarget.value;
+                        if (!this.state.userId) 
+                            storage.secureStorage.removeItem('userId');
+                        else
+                            storage.secureStorage.setItem('userId', this.state.userId);
+                    }} 
+                    value={this.state.userId} 
+                    placeholder="User Name: Change if sharing remote server"
                 ></sp-textfield>
                 <div className="button-box">
                     <sp-button 

--- a/photoshop/src/panels/Main.jsx
+++ b/photoshop/src/panels/Main.jsx
@@ -58,14 +58,12 @@ export default class Main extends React.Component {
                 <sp-divider />
                 <div id="connection-more" className={expandMore ? "expand-menu expand" : "expand-menu collapse"}>
                     <div class="expand-menu-title" onClick={() => { this.setState({ui_ExpandMore: !expandMore}) }}>
-                        <sp-label class="expand-menu-arrow">{expandMore ? "▼" : "▶️"}</sp-label>
-                        {/* <sp-icon size="s" name={expandMore ? "ui:ChevronDownSmall" : "ui:ChevronRightSmall"}></sp-icon> */}
-                        <sp-label>more</sp-label>
+                        <sp-label>{expandMore ? "▼ more" : "▶ more"}</sp-label>
                     </div>
                     <div class="content">
-                        <div class="input-row">
-                            <sp-label>user-id:</sp-label>
-                            <div class="input-label" id="user-id-bar">
+                        <div class="input-row" id="user-id-bar">
+                            <sp-label>user-name:</sp-label>
+                            <div class="input-label">
                                 <sp-label>{this.state.userId}</sp-label>
                                 <sp-textfield 
                                     label="USER ID" 

--- a/photoshop/src/styles.css
+++ b/photoshop/src/styles.css
@@ -24,6 +24,9 @@
 #url-bar {
     width: 100%;
 }
+#user-id-bar {
+    width: 100%;
+}
 .button-box {
     width: 100%;
     display: flex;

--- a/photoshop/src/styles.css
+++ b/photoshop/src/styles.css
@@ -42,10 +42,12 @@
     flex-direction: row;
     align-items: center;
     height: 30px;
+    width: 100%;
 }
 
 .input-label {
     position: relative;
+    flex: 1;
 }
 .input-label sp-label {
     width: calc(100% - 15px);
@@ -70,13 +72,12 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    height: 20px;
+    height: 15px;
     padding: 5px;
-    background-color: rgba(0, 0, 0, 0.3);
 }
 .expand-menu .expand-menu-arrow {
     font-weight: bold;
-    width: 15px;
+    text-align: center;
 }
 .expand-menu .expand-menu-title sp-icon {
     height: 15px;

--- a/photoshop/src/styles.css
+++ b/photoshop/src/styles.css
@@ -37,3 +37,58 @@
 #connect-btn {
     text-align: center;
 }
+.input-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 30px;
+}
+
+.input-label {
+    position: relative;
+}
+.input-label sp-label {
+    width: calc(100% - 15px);
+    height: 100%;
+    margin-left: 15px;
+}
+.input-label sp-textfield {
+    position: absolute;
+    width: 100%;
+    top: -5px;
+    left: 0;
+    visibility: hidden;
+    z-index: 5;
+}
+.input-label sp-textfield:focus {
+    visibility: visible;
+} 
+.input-label:hover sp-textfield{
+    visibility: visible;
+}
+.expand-menu .expand-menu-title {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 20px;
+    padding: 5px;
+    background-color: rgba(0, 0, 0, 0.3);
+}
+.expand-menu .expand-menu-arrow {
+    font-weight: bold;
+    width: 15px;
+}
+.expand-menu .expand-menu-title sp-icon {
+    height: 15px;
+    width: 20px;
+    color: #ccc;
+}
+.expand-menu .content {
+    margin-left: 15px
+}
+.expand-menu.collapse .content {
+    display: none;
+}
+.expand-menu.expand .content {
+    display: flex;
+}

--- a/photoshop/src/system/ComfyConnection.js
+++ b/photoshop/src/system/ComfyConnection.js
@@ -21,11 +21,11 @@ class ComfyConnection {
         });
     }
 
-    static createInstance(comfyURL) {
+    static createInstance(comfyURL, userId) {
         if (ComfyConnection.instance && ComfyConnection.instance.isConnected) {
             ComfyConnection.instance.disconnect();
         }
-        ComfyConnection.instance = new ComfyConnection(comfyURL);
+        ComfyConnection.instance = new ComfyConnection(comfyURL, userId);
     }
 
     get isConnected() {
@@ -34,9 +34,16 @@ class ComfyConnection {
 
     comfyURL = '';
     interval = null;
-    constructor(comfyURL) {
+    constructor(comfyURL, userId) {
         ComfyConnection.instance = this;
+        if (!comfyURL) {
+            comfyURL = 'http://127.0.0.1:8188';
+        }
         this.comfyURL = comfyURL.replace(/\/*$/, '');
+        if (!userId) {
+            userId = '';
+        }
+        this.userId = userId;
         this.connect();
     }
     connect() {
@@ -61,7 +68,8 @@ class ComfyConnection {
             path: '/sd-ppp/',
             query: {
                 version: 1,
-                type: 'photoshop'
+                type: 'photoshop',
+                user_id: this.userId,
             }
         });
         this.interval = setInterval(() => {

--- a/photoshop/src/system/events/get_image.js
+++ b/photoshop/src/system/events/get_image.js
@@ -1,6 +1,7 @@
 import { app, imaging } from "photoshop";
 import { executeAsModalUntilSuccess, findInAllSubLayer, unTrimImageData } from '../util.js';
 import Jimp from "../library/jimp.min";
+import { SPECIAL_LAYER_NAME_TO_ID, SPECIAL_LAYER_USE_SELECTION } from "../util";
 
 function isLayerFolder(layer){
     return layer.layers && layer.layers.length > 0;
@@ -81,8 +82,8 @@ function getDesiredBounds(boundsLayerID) {
         width: app.activeDocument.width,
         height: app.activeDocument.height
     };
-    // if boundsLayerID == -1, use selection bounds
-    if (boundsLayerID == -1) {
+    // use selection bounds
+    if (boundsLayerID == SPECIAL_LAYER_NAME_TO_ID[SPECIAL_LAYER_USE_SELECTION]) {
         // if no selection use document bounds
         const selectionBounds = app.activeDocument.selection?.bounds;
         if (!selectionBounds) return docBounds;
@@ -130,7 +131,7 @@ export default async function getImage(comfyURL, params) {
         const startTime = Date.now();
         let layer;
         let isFolder = false;
-        const activeLayers = app.activeDocument.activeLayers;
+        const activeLayers = app.activeDocument?.activeLayers;
         try {
             hostControl = executionContext.hostControl;
             suspensionID = await hostControl.suspendHistory({

--- a/photoshop/src/system/events/send_images.js
+++ b/photoshop/src/system/events/send_images.js
@@ -2,16 +2,7 @@ import { app, imaging } from "photoshop";
 import { executeAsModalUntilSuccess} from '../util.js';
 import Jimp from "../library/jimp.min";
 
-const SPECIAL_LAYER_USE_CANVAS = '### Use Canvas ###'
-const SPECIAL_LAYER_USE_SELECTION = '### Use Selection ###'
-const SPECIAL_LAYER_NEW_LAYER = '### New Layer ###'
-const SPECIAL_LAYER_SAME_AS_LAYER = '### Same as Layer ###'
-const SPECIAL_LAYER_NAME_TO_ID = {
-    SPECIAL_LAYER_USE_CANVAS: 0,
-    SPECIAL_LAYER_USE_SELECTION: -1,
-    SPECIAL_LAYER_NEW_LAYER: -2,
-    SPECIAL_LAYER_SAME_AS_LAYER: -3
-}
+import { SPECIAL_LAYER_NAME_TO_ID, SPECIAL_LAYER_NEW_LAYER } from '../util.js';
 
 function autocrop(jimp) {
     let minX = jimp.bitmap.width - 1;

--- a/photoshop/src/system/util.js
+++ b/photoshop/src/system/util.js
@@ -1,5 +1,16 @@
 import { core } from "photoshop";
 
+export const SPECIAL_LAYER_USE_CANVAS = '### Use Canvas ###'
+export const SPECIAL_LAYER_USE_SELECTION = '### Use Selection ###'
+export const SPECIAL_LAYER_NEW_LAYER = '### New Layer ###'
+export const SPECIAL_LAYER_SAME_AS_LAYER = '### Same as Layer ###'
+export const SPECIAL_LAYER_NAME_TO_ID = {
+    SPECIAL_LAYER_USE_CANVAS: 0,
+    SPECIAL_LAYER_USE_SELECTION: -1,
+    SPECIAL_LAYER_NEW_LAYER: -2,
+    SPECIAL_LAYER_SAME_AS_LAYER: -3
+}
+
 export function unTrimImageData(
     intersectImageDataArray,
     toImageDataArray,
@@ -68,7 +79,7 @@ export function getAllSubLayer(layer, level = 0) {
 }
 
 export function findInAllSubLayer(layer, layerid) {
-    if (!layer.layers) return null;
+    if (!layer?.layers) return null;
     for (let i = 0; i < layer.layers.length; i++) {
         if (layer.layers[i].id === layerid) return layer.layers[i];
 

--- a/photoshop/src/system/util.js
+++ b/photoshop/src/system/util.js
@@ -5,10 +5,10 @@ export const SPECIAL_LAYER_USE_SELECTION = '### Use Selection ###'
 export const SPECIAL_LAYER_NEW_LAYER = '### New Layer ###'
 export const SPECIAL_LAYER_SAME_AS_LAYER = '### Same as Layer ###'
 export const SPECIAL_LAYER_NAME_TO_ID = {
-    SPECIAL_LAYER_USE_CANVAS: 0,
-    SPECIAL_LAYER_USE_SELECTION: -1,
-    SPECIAL_LAYER_NEW_LAYER: -2,
-    SPECIAL_LAYER_SAME_AS_LAYER: -3
+    [SPECIAL_LAYER_USE_CANVAS]: 0,
+    [SPECIAL_LAYER_USE_SELECTION]: -1,
+    [SPECIAL_LAYER_NEW_LAYER]: -2,
+    [SPECIAL_LAYER_SAME_AS_LAYER]: -3
 }
 
 export function unTrimImageData(


### PR DESCRIPTION
NOTE: This pr is based on #6. It contains #6 contents up to f2b4113
Adding support for matching multiple connected web clients and PS instances under all conditions.
Under most cases, client-server-ps matching will be automatic using the information server got from the clients, and the experience will be the same as for single user, but for some special cases, a user name will need to be set.

Client-Server-PS matching logic is:
1. If there is only one PS instance per web client IP address, all the client with the same ip address will use the one PS instance. So in most cases, which will be: local server, private remote server, even on public server, people with different public ip addresses are ok. 
2. Problem will be when multiple PS instances are under the same public ip address (VPN, behind NAT, etc), multiple users with multiple PS instances will be under the same IP address. In that case, user will have to input matching user name in ComfyUI Settings-> SD-PPP User Name, and in PS plugin, so the server knows which PS instance to use.

User name logic in detail:
By default, if the ComfyUI server is run with --multi-user flag set(which may very well be if the server is shared), SD-PPP user name setting in ComfyUI settings will be set to ComfyUI's user name, so in PS plugin, the user will only have to input that User Name.
If the ComfyUI is not run with --multi-user flag but still used as a shared server, user has to change the SD-PPP user name settings manually, matching the PS plugin's user name.

PS plugin:
![image](https://github.com/zombieyang/sd-ppp/assets/12490479/28754efa-1db4-46f0-987f-c462826fa60b)

ComfyUI settings(Multi-User)
![image](https://github.com/zombieyang/sd-ppp/assets/12490479/ea9840a6-66de-4212-b5ed-8d75ca2137a5)

ComfyUI settings(Single-User)
![image](https://github.com/zombieyang/sd-ppp/assets/12490479/eb3f2c8f-ae91-4729-8f0b-66b0aa11ef23)


