### PR TITLE
fix: SendImage Node result cannot send back to PS plugin

### DIFF
--- a/typescripts/src/sdsystem/comfy/comfy-entry.mts
+++ b/typescripts/src/sdsystem/comfy/comfy-entry.mts
@@ -72,7 +72,7 @@ async function _init(app: any, api: any, $el: any) {
 					layer_identifies: ev.detail.output.images.map(() => SpeicialIDManager.getSpecialLayerForSend()[0]),
 					boundaries: ev.detail.output.images.map(() => ''),
 					image_urls: ev.detail.output.images.map((image: any) => {
-						return location.origin + '/api/view?type=temp&filename=' + image.filename
+						return location.origin + '/api/view?type=' + image.type + '&filename=' + image.filename
 					}),
 				})
 			}


### PR DESCRIPTION
对于SaveImage节点 在结果列表取值时 `output.image.type` 是 `output` 并不是 `temp`，在这里根据 `output.image.type` 的取值动态的配置生成图片路径，避免工作流实际执行成功但是ps插件获取不到结果