### PR TITLE
Fix: The image results of some workflows cannot be transmitted to Photoshop

### DIFF
--- a/typescripts/src/sdsystem/comfy/comfy-entry.mts
+++ b/typescripts/src/sdsystem/comfy/comfy-entry.mts
@@ -40,9 +40,13 @@ async function _init(app: any, api: any, $el: any) {
 		if (node)
 			pageStore.setExecutingNodeTitle(node.title);
 	})
-	api.addEventListener("execution_success", () => {
+	api.addEventListener("execution_success", (ev: any) => {
 		pageStore.setProgress(0);
 		pageStore.setExecutingNodeTitle('');
+		if (PreviewSender.get(ev.detail.prompt_id)) {
+			PreviewSender.delete(ev.detail.prompt_id);
+
+		}
 	});
 	api.addEventListener("execution_interrupted", () => {
 		pageStore.setProgress(0);
@@ -53,11 +57,10 @@ async function _init(app: any, api: any, $el: any) {
 	})
 	const promptsFromSDPPPBackend = new Map<string, string>();
 	api.addEventListener("executed", (ev: any) => {
-		if (ev.detail.output) {
+		if (ev.detail.output && Array.isArray(ev.detail.output.images) && ev.detail.output.images.length > 0) {
 			let fromSID = null;
 			if (PreviewSender.get(ev.detail.prompt_id)) {
 				fromSID = PreviewSender.get(ev.detail.prompt_id);
-				PreviewSender.delete(ev.detail.prompt_id);
 
 			} else {
 				// consider if it neccesary


### PR DESCRIPTION
这个改动修复了两个问题

- 当工作流executed结果为文本内容时，会触发同步到PS逻辑，但是无法获取到图片结果并在Console中报错
- 当工作流有多个executed结果时，仅有第一个executed触发同步到PS逻辑，后续结果无法同步到PS